### PR TITLE
Implement sub group reduce

### DIFF
--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce.h
@@ -519,6 +519,50 @@ __parallel_transform_reduce(_ExecutionPolicy&& __exec, _ReduceOp __reduce_op, _T
     // Use single work group implementation if array < __work_group_size * __iters_per_work_item.
     if (__work_group_size >= 256)
     {
+#ifdef USE_SUB_GROUP_REDUCE
+        if (__n <= 32)
+        {
+            return __parallel_transform_reduce_sub_group_impl<32, 1, _Tp, _isComm>(
+                ::std::forward<_ExecutionPolicy>(__exec), __n, __reduce_op, __transform_op, __init,
+                ::std::forward<_Ranges>(__rngs)...);
+        }
+        else if (__n <= 64)
+        {
+            return __parallel_transform_reduce_sub_group_impl<32, 2, _Tp, _isComm>(
+                ::std::forward<_ExecutionPolicy>(__exec), __n, __reduce_op, __transform_op, __init,
+                ::std::forward<_Ranges>(__rngs)...);
+        }
+        else if (__n <= 128)
+        {
+            return __parallel_transform_reduce_sub_group_impl<32, 4, _Tp, _isComm>(
+                ::std::forward<_ExecutionPolicy>(__exec), __n, __reduce_op, __transform_op, __init,
+                ::std::forward<_Ranges>(__rngs)...);
+        }
+        else if (__n <= 256)
+        {
+            return __parallel_transform_reduce_sub_group_impl<32, 8, _Tp, _isComm>(
+                ::std::forward<_ExecutionPolicy>(__exec), __n, __reduce_op, __transform_op, __init,
+                ::std::forward<_Ranges>(__rngs)...);
+        }
+        else if (__n <= 512)
+        {
+            return __parallel_transform_reduce_sub_group_impl<32, 16, _Tp, _isComm>(
+                ::std::forward<_ExecutionPolicy>(__exec), __n, __reduce_op, __transform_op, __init,
+                ::std::forward<_Ranges>(__rngs)...);
+        }
+        else if (__n <= 1024)
+        {
+            return __parallel_transform_reduce_sub_group_impl<32, 32, _Tp, _isComm>(
+                ::std::forward<_ExecutionPolicy>(__exec), __n, __reduce_op, __transform_op, __init,
+                ::std::forward<_Ranges>(__rngs)...);
+        }
+        else if (__n <= 2048)
+        {
+            return __parallel_transform_reduce_sub_group_impl<32, 64, _Tp, _isComm>(
+                ::std::forward<_ExecutionPolicy>(__exec), __n, __reduce_op, __transform_op, __init,
+                ::std::forward<_Ranges>(__rngs)...);
+        }
+#else // USE_SUB_GROUP_REDUCE
         if (__n <= 256)
         {
             return __parallel_transform_reduce_small_impl<256, 1, _Tp, _isComm>(
@@ -543,6 +587,7 @@ __parallel_transform_reduce(_ExecutionPolicy&& __exec, _ReduceOp __reduce_op, _T
                 ::std::forward<_ExecutionPolicy>(__exec), __n, __reduce_op, __transform_op, __init,
                 ::std::forward<_Ranges>(__rngs)...);
         }
+#endif
         else if (__n <= 4096)
         {
             return __parallel_transform_reduce_small_impl<256, 16, _Tp, _isComm>(

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
@@ -21,7 +21,6 @@
 
 #include "../../onedpl_config.h"
 #include "../../utils.h"
-#include "../../iterator_impl.h"
 #include "sycl_defs.h"
 
 namespace oneapi


### PR DESCRIPTION
This PR adds support for `reduce_over_sub_group`. It is wired into the existing reduce and can be enabled with `USE_SUB_GROUP_REDUCE`