### PR TITLE
Remove local_accessor from global loads

### DIFF
--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce.h
@@ -57,11 +57,10 @@ __group_reduce_kernel(const _NDItemId& __item_id, const _Size& __n, _TransformPa
     auto __local_idx = __item_id.get_local_id(0);
     auto __group_size = __item_id.get_local_range().size();
     // 1. Initialization (transform part). Fill local memory
-    __transform_pattern(__item_id, __n, /*global_offset*/ (_Size)0, __local_mem, __acc...);
-    __dpl_sycl::__group_barrier(__item_id);
+    _Tp __result = __transform_pattern(__item_id, __n, /*global_offset*/ (_Size)0, __acc...);
     const _Size __n_items = __transform_pattern.output_size(__n, __group_size);
     // 2. Reduce within work group using local memory
-    _Tp __result = __reduce_pattern(__item_id, __n_items, __local_mem);
+    __result = __reduce_pattern(__item_id, __n_items, __result, __local_mem);
     if (__local_idx == 0)
     {
         __reduce_pattern.apply_init(__init, __result);
@@ -81,11 +80,10 @@ __device_reduce_kernel(const _NDItemId& __item_id, const _Size& __n, _TransformP
     auto __group_idx = __item_id.get_group(0);
     auto __group_size = __item_id.get_local_range().size();
     // 1. Initialization (transform part). Fill local memory
-    __transform_pattern(__item_id, __n, /*global_offset*/ (_Size)0, __local_mem, __acc...);
-    __dpl_sycl::__group_barrier(__item_id);
+    _Tp __result = __transform_pattern(__item_id, __n, /*global_offset*/ (_Size)0, __acc...);
     const _Size __n_items = __transform_pattern.output_size(__n, __group_size);
     // 2. Reduce within work group using local memory
-    _Tp __result = __reduce_pattern(__item_id, __n_items, __local_mem);
+    __result = __reduce_pattern(__item_id, __n_items, __result, __local_mem);
     if (__local_idx == 0)
         __temp_acc[__group_idx] = __result;
 }
@@ -114,7 +112,7 @@ struct __parallel_transform_reduce_sub_group_submitter<__sub_group_size, __iters
                _InitType __init, _Ranges&&... __rngs) const
     {
         auto __transform_pattern =
-            unseq_backend::transform_reduce<_ExecutionPolicy, __iters_per_work_item, _ReduceOp, _TransformOp, _isComm>{
+            unseq_backend::transform_reduce<_ExecutionPolicy, __iters_per_work_item, _ReduceOp, _TransformOp, _Tp, _isComm>{
                 __reduce_op, __transform_op};
         auto __reduce_pattern = unseq_backend::reduce_over_sub_group<_ExecutionPolicy, _ReduceOp, _Tp, _isComm>{__reduce_op};
 
@@ -123,8 +121,7 @@ struct __parallel_transform_reduce_sub_group_submitter<__sub_group_size, __iters
         sycl::event __reduce_event = __exec.queue().submit([&, __n](sycl::handler& __cgh) {
             oneapi::dpl::__ranges::__require_access(__cgh, __rngs...); // get an access to data under SYCL buffer
             sycl::accessor __res_acc{__res, __cgh, sycl::write_only, __dpl_sycl::__no_init{}};
-            ::std::size_t __local_mem_size = std::max(__transform_pattern.local_mem_req(__sub_group_size),
-                                                      __reduce_pattern.local_mem_req(__sub_group_size));
+            ::std::size_t __local_mem_size = __reduce_pattern.local_mem_req(__sub_group_size);
             __dpl_sycl::__local_accessor<_Tp> __temp_local(sycl::range<1>(__local_mem_size), __cgh);
             __cgh.parallel_for<_Name...>(
                 sycl::nd_range<1>(sycl::range<1>(__sub_group_size), sycl::range<1>(__sub_group_size)),
@@ -175,7 +172,7 @@ struct __parallel_transform_reduce_small_submitter<__work_group_size, __iters_pe
                _InitType __init, _Ranges&&... __rngs) const
     {
         auto __transform_pattern =
-            unseq_backend::transform_reduce<_ExecutionPolicy, __iters_per_work_item, _ReduceOp, _TransformOp, _isComm>{
+            unseq_backend::transform_reduce<_ExecutionPolicy, __iters_per_work_item, _ReduceOp, _TransformOp, _Tp, _isComm>{
                 __reduce_op, __transform_op};
         auto __reduce_pattern = unseq_backend::reduce_over_group<_ExecutionPolicy, _ReduceOp, _Tp>{__reduce_op};
 
@@ -184,8 +181,7 @@ struct __parallel_transform_reduce_small_submitter<__work_group_size, __iters_pe
         sycl::event __reduce_event = __exec.queue().submit([&, __n](sycl::handler& __cgh) {
             oneapi::dpl::__ranges::__require_access(__cgh, __rngs...); // get an access to data under SYCL buffer
             sycl::accessor __res_acc{__res, __cgh, sycl::write_only, __dpl_sycl::__no_init{}};
-            ::std::size_t __local_mem_size = std::max(__transform_pattern.local_mem_req(__work_group_size),
-                                                      __reduce_pattern.local_mem_req(__work_group_size));
+            ::std::size_t __local_mem_size = __reduce_pattern.local_mem_req(__work_group_size);
             __dpl_sycl::__local_accessor<_Tp> __temp_local(sycl::range<1>(__local_mem_size), __cgh);
             __cgh.parallel_for<_Name...>(
                 sycl::nd_range<1>(sycl::range<1>(__work_group_size), sycl::range<1>(__work_group_size)),
@@ -237,7 +233,7 @@ struct __parallel_transform_reduce_device_kernel_submitter<__work_group_size, __
                _InitType __init, sycl::buffer<_Tp>& __temp, _Ranges&&... __rngs) const
     {
         auto __transform_pattern =
-            unseq_backend::transform_reduce<_ExecutionPolicy, __iters_per_work_item, _ReduceOp, _TransformOp, _isComm>{
+            unseq_backend::transform_reduce<_ExecutionPolicy, __iters_per_work_item, _ReduceOp, _TransformOp, _Tp, _isComm>{
                 __reduce_op, __transform_op};
         auto __reduce_pattern = unseq_backend::reduce_over_group<_ExecutionPolicy, _ReduceOp, _Tp>{__reduce_op};
 
@@ -248,8 +244,7 @@ struct __parallel_transform_reduce_device_kernel_submitter<__work_group_size, __
         return __exec.queue().submit([&, __n](sycl::handler& __cgh) {
             oneapi::dpl::__ranges::__require_access(__cgh, __rngs...); // get an access to data under SYCL buffer
             sycl::accessor __temp_acc{__temp, __cgh, sycl::write_only, __dpl_sycl::__no_init{}};
-            ::std::size_t __local_mem_size = std::max(__transform_pattern.local_mem_req(__work_group_size),
-                                                      __reduce_pattern.local_mem_req(__work_group_size));
+            ::std::size_t __local_mem_size = __reduce_pattern.local_mem_req(__work_group_size);
             __dpl_sycl::__local_accessor<_Tp> __temp_local(sycl::range<1>(__local_mem_size), __cgh);
             __cgh.parallel_for<_KernelName...>(
                 sycl::nd_range<1>(sycl::range<1>(__n_groups * __work_group_size), sycl::range<1>(__work_group_size)),
@@ -281,7 +276,7 @@ struct __parallel_transform_reduce_work_group_kernel_submitter<__work_group_size
     {
         using _NoOpFunctor = unseq_backend::walk_n<_ExecutionPolicy, oneapi::dpl::__internal::__no_op>;
         auto __transform_pattern =
-            unseq_backend::transform_reduce<_ExecutionPolicy, __iters_per_work_item, _ReduceOp, _NoOpFunctor, _isComm>{
+            unseq_backend::transform_reduce<_ExecutionPolicy, __iters_per_work_item, _ReduceOp, _NoOpFunctor, _Tp, _isComm>{
                 __reduce_op, _NoOpFunctor{}};
         auto __reduce_pattern = unseq_backend::reduce_over_group<_ExecutionPolicy, _ReduceOp, _Tp>{__reduce_op};
 
@@ -304,8 +299,7 @@ struct __parallel_transform_reduce_work_group_kernel_submitter<__work_group_size
 
             sycl::accessor __temp_acc{__temp, __cgh, sycl::read_only};
             sycl::accessor __res_acc{__res, __cgh, sycl::write_only, __dpl_sycl::__no_init{}};
-            ::std::size_t __local_mem_size = std::max(__transform_pattern.local_mem_req(__work_group_size),
-                                                      __reduce_pattern.local_mem_req(__work_group_size));
+            ::std::size_t __local_mem_size = __reduce_pattern.local_mem_req(__work_group_size);
             __dpl_sycl::__local_accessor<_Tp> __temp_local(sycl::range<1>(__local_mem_size), __cgh);
 
             __cgh.parallel_for<_KernelName...>(
@@ -373,10 +367,10 @@ struct __parallel_transform_reduce_impl
             __reduce_kernel, _CustomName, _ReduceOp, _TransformOp, _NoOpFunctor, _Ranges...>;
 
         auto __transform_pattern1 =
-            unseq_backend::transform_reduce<_ExecutionPolicy, __iters_per_work_item, _ReduceOp, _TransformOp, _isComm>{
+            unseq_backend::transform_reduce<_ExecutionPolicy, __iters_per_work_item, _ReduceOp, _TransformOp, _Tp, _isComm>{
                 __reduce_op, __transform_op};
         auto __transform_pattern2 =
-            unseq_backend::transform_reduce<_ExecutionPolicy, __iters_per_work_item, _ReduceOp, _NoOpFunctor, _isComm>{
+            unseq_backend::transform_reduce<_ExecutionPolicy, __iters_per_work_item, _ReduceOp, _NoOpFunctor, _Tp, _isComm>{
                 __reduce_op, _NoOpFunctor{}};
         auto __reduce_pattern = unseq_backend::reduce_over_group<_ExecutionPolicy, _ReduceOp, _Tp>{__reduce_op};
 
@@ -412,8 +406,7 @@ struct __parallel_transform_reduce_impl
                 oneapi::dpl::__ranges::__require_access(__cgh, __rngs...); // get an access to data under SYCL buffer
                 sycl::accessor __temp_acc{__temp, __cgh, sycl::read_write};
                 sycl::accessor __res_acc{__res, __cgh, sycl::write_only, __dpl_sycl::__no_init{}};
-                ::std::size_t __local_mem_size = std::max(__transform_pattern1.local_mem_req(__work_group_size),
-                                                          __reduce_pattern.local_mem_req(__work_group_size));
+                ::std::size_t __local_mem_size = __reduce_pattern.local_mem_req(__work_group_size);
                 __dpl_sycl::__local_accessor<_Tp> __temp_local(sycl::range<1>(__local_mem_size), __cgh);
 #if _ONEDPL_COMPILE_KERNEL && _ONEDPL_KERNEL_BUNDLE_PRESENT
                 __cgh.use_kernel_bundle(__kernel.get_kernel_bundle());
@@ -429,20 +422,21 @@ struct __parallel_transform_reduce_impl
                         auto __group_idx = __item_id.get_group(0);
                         // 1. Initialization (transform part). Fill local memory
                         _Size __n_items;
+                        _Tp __result;
+
                         if (__is_first)
                         {
-                            __transform_pattern1(__item_id, __n, /*global_offset*/ (_Size)0, __temp_local, __rngs...);
+                            __result = __transform_pattern1(__item_id, __n, /*global_offset*/ (_Size)0, __rngs...);
                             __n_items = __transform_pattern1.output_size(__n, __work_group_size);
                         }
                         else
                         {
-                            __transform_pattern2(__item_id, __n, __offset_2, __temp_local, __temp_acc);
+                            __result = __transform_pattern2(__item_id, __n, __offset_2,  __temp_acc);
                             __n_items = __transform_pattern2.output_size(__n, __work_group_size);
                         }
 
-                        __dpl_sycl::__group_barrier(__item_id);
                         // 2. Reduce within work group using local memory
-                        _Tp __result = __reduce_pattern(__item_id, __n_items, __temp_local);
+                        __result = __reduce_pattern(__item_id, __n_items, __result, __temp_local);
                         if (__local_idx == 0)
                         {
                             // final reduction

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce.h
@@ -121,8 +121,7 @@ struct __parallel_transform_reduce_sub_group_submitter<__sub_group_size, __iters
         sycl::event __reduce_event = __exec.queue().submit([&, __n](sycl::handler& __cgh) {
             oneapi::dpl::__ranges::__require_access(__cgh, __rngs...); // get an access to data under SYCL buffer
             sycl::accessor __res_acc{__res, __cgh, sycl::write_only, __dpl_sycl::__no_init{}};
-            ::std::size_t __local_mem_size = __reduce_pattern.local_mem_req(__sub_group_size);
-            __dpl_sycl::__local_accessor<_Tp> __temp_local(sycl::range<1>(__local_mem_size), __cgh);
+            __dpl_sycl::__local_accessor<_Tp> __temp_local(sycl::range<1>(0), __cgh);
             __cgh.parallel_for<_Name...>(
                 sycl::nd_range<1>(sycl::range<1>(__sub_group_size), sycl::range<1>(__sub_group_size)),
                 [=](sycl::nd_item<1> __item_id) [[sycl::reqd_sub_group_size(__sub_group_size)]] {

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
@@ -463,7 +463,7 @@ struct reduce_over_sub_group
 
     template <typename _NDItemId, typename _Size, typename _AccLocal>
     inline _Tp
-    reduce_impl(const _NDItemId& __item_id, const _Size& __n, const _Tp& __val, const _AccLocal& __local_mem,
+    reduce_impl(const _NDItemId& __item_id, const _Size& __n, const _Tp& __val,
                 std::true_type /*has_known_identity*/) const
     {
       auto __sg = __item_id.get_sub_group();
@@ -479,7 +479,7 @@ struct reduce_over_sub_group
  
     template <typename _NDItemId, typename _Size, typename _AccLocal>
     inline _Tp
-    reduce_impl(const _NDItemId& __item_id, const _Size& __n, const _Tp& __val, const _AccLocal& __local_mem,
+    reduce_impl(const _NDItemId& __item_id, const _Size& __n, const _Tp& __val,
                 std::false_type /*has_known_identity*/) const
     {
       auto __sg = __item_id.get_sub_group();
@@ -491,9 +491,9 @@ struct reduce_over_sub_group
 
     template <typename _NDItemId, typename _Size, typename _AccLocal>
     inline _Tp
-    operator()(const _NDItemId& __item_id, const _Size& __n, const _Tp& __val, const _AccLocal& __local_mem) const
+    operator()(const _NDItemId& __item_id, const _Size& __n, const _Tp& __val, const _AccLocal& /*__local_mem*/) const
     {
-        return reduce_impl(__item_id, __n, __val, __local_mem, __has_known_identity<_BinaryOperation1, _Tp>{});
+        return reduce_impl(__item_id, __n, __val, __has_known_identity<_BinaryOperation1, _Tp>{});
     }
 
     template <typename _InitType, typename _Result>
@@ -501,12 +501,6 @@ struct reduce_over_sub_group
     apply_init(const _InitType& __init, _Result&& __result) const
     {
         __init_processing<_Tp>{}(__init, __result, __bin_op1);
-    }
-
-    inline ::std::size_t
-    local_mem_req(const ::std::uint16_t& __work_group_size) const
-    {
-        return __work_group_size;
     }
 };
 


### PR DESCRIPTION
This PR removes the use of the local accessor from global loads. This also removes the unnecessary barrier between the global load and the reduce over group. 