### PR TITLE
Unify scratch memory with buffers

### DIFF
--- a/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
@@ -402,8 +402,7 @@ __pattern_min_element(_ExecutionPolicy&& __exec, _Iterator __first, _Iterator __
                                                                        decltype(__identity_init_fn), false>(
             ::std::forward<_ExecutionPolicy>(__exec), __identity_reduce_fn, __identity_init_fn,
             unseq_backend::__no_init_value{}, // no initial value
-            __buf.all_view())
-            .get();
+            __buf.all_view());
 
     return __first + ::std::get<0>(__ret_idx);
 }
@@ -449,8 +448,7 @@ __pattern_minmax_element(_ExecutionPolicy&& __exec, _Iterator __first, _Iterator
                                                                                 decltype(__identity_init_fn), false>(
                      ::std::forward<_ExecutionPolicy>(__exec), _ReduceFnType{__comp}, __identity_init_fn,
                      unseq_backend::__no_init_value{}, // no initial value
-                     __buf.all_view())
-                     .get();
+                     __buf.all_view());
 
     return ::std::make_pair<_Iterator, _Iterator>(__first + ::std::get<0>(__ret), __first + ::std::get<1>(__ret));
 }
@@ -542,8 +540,7 @@ __pattern_count(_ExecutionPolicy&& __exec, _Iterator __first, _Iterator __last, 
                _ReduceValueType, decltype(__identity_reduce_fn), decltype(__identity_init_fn), true>(
                ::std::forward<_ExecutionPolicy>(__exec), __identity_reduce_fn, __identity_init_fn,
                unseq_backend::__no_init_value{}, // no initial value
-               __buf.all_view())
-        .get();
+               __buf.all_view());
 }
 
 //------------------------------------------------------------------------
@@ -1013,8 +1010,7 @@ __pattern_is_partitioned(_ExecutionPolicy&& __exec, _Iterator __first, _Iterator
                                                                        decltype(__identity_init_fn), false>(
             ::std::forward<_ExecutionPolicy>(__exec), __identity_reduce_fn, __identity_init_fn,
             unseq_backend::__no_init_value{}, // no initial value
-            __buf.all_view())
-            .get();
+            __buf.all_view());
 
     return __broken != __identity_reduce_fn(_ReduceValueType{__all_true}, __res);
 }
@@ -1313,8 +1309,7 @@ __pattern_lexicographical_compare(_ExecutionPolicy&& __exec, _Iterator1 __first1
                                                                        decltype(__identity_init_fn), false>(
             ::std::forward<_ExecutionPolicy>(__exec), __identity_reduce_fn, __identity_init_fn,
             unseq_backend::__no_init_value{}, // no initial value
-            __buf1.all_view(), __buf2.all_view())
-            .get();
+            __buf1.all_view(), __buf2.all_view());
 
     return __ret_idx ? __ret_idx == 1 : (__last1 - __first1) < (__last2 - __first2);
 }

--- a/include/oneapi/dpl/pstl/hetero/numeric_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/numeric_impl_hetero.h
@@ -60,8 +60,7 @@ __pattern_transform_reduce(_ExecutionPolicy&& __exec, _RandomAccessIterator1 __f
     return oneapi::dpl::__par_backend_hetero::__parallel_transform_reduce<_RepackedTp, _BinaryOperation1, _Functor, true>(
                ::std::forward<_ExecutionPolicy>(__exec), __binary_op1, _Functor{__binary_op2},
                unseq_backend::__init_value<_RepackedTp>{__init}, // initial value
-               __buf1.all_view(), __buf2.all_view())
-        .get();
+               __buf1.all_view(), __buf2.all_view());
 }
 
 //------------------------------------------------------------------------
@@ -87,8 +86,7 @@ __pattern_transform_reduce(_ExecutionPolicy&& __exec, _ForwardIterator __first, 
     return oneapi::dpl::__par_backend_hetero::__parallel_transform_reduce<_RepackedTp, _BinaryOperation, _Functor, true>(
                ::std::forward<_ExecutionPolicy>(__exec), __binary_op, _Functor{__unary_op},
                unseq_backend::__init_value<_RepackedTp>{__init}, // initial value
-               __buf.all_view())
-        .get();
+               __buf.all_view());
 }
 
 //------------------------------------------------------------------------


### PR DESCRIPTION
This PR makes the mid size reduce allocate memory in one buffer rather than two. It also removes the use of __future as a return to account for the more fine grained control we need over the memory.