### PR TITLE
Add additional reduce cases

### DIFF
--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce.h
@@ -465,6 +465,36 @@ __parallel_transform_reduce(_ExecutionPolicy&& __exec, _ReduceOp __reduce_op, _T
         // Use two-step tree reduction.
         // First step reduces __work_group_size * __iters_per_work_item_device_kernel elements.
         // Second step reduces __work_group_size * __iters_per_work_item_work_group_kernel elements.
+        else if (__n <= 65536)
+        {
+            return __parallel_transform_reduce_mid_impl<_Tp, 256, 1, 1>(::std::forward<_ExecutionPolicy>(__exec), __n,
+                                                                        __reduce_op, __transform_op, __init,
+                                                                        ::std::forward<_Ranges>(__rngs)...);
+        }
+        else if (__n <= 131072)
+        {
+            return __parallel_transform_reduce_mid_impl<_Tp, 256, 2, 1>(::std::forward<_ExecutionPolicy>(__exec), __n,
+                                                                        __reduce_op, __transform_op, __init,
+                                                                        ::std::forward<_Ranges>(__rngs)...);
+        }
+        else if (__n <= 262144)
+        {
+            return __parallel_transform_reduce_mid_impl<_Tp, 256, 4, 1>(::std::forward<_ExecutionPolicy>(__exec), __n,
+                                                                        __reduce_op, __transform_op, __init,
+                                                                        ::std::forward<_Ranges>(__rngs)...);
+        }
+        else if (__n <= 524288)
+        {
+            return __parallel_transform_reduce_mid_impl<_Tp, 256, 8, 1>(::std::forward<_ExecutionPolicy>(__exec), __n,
+                                                                        __reduce_op, __transform_op, __init,
+                                                                        ::std::forward<_Ranges>(__rngs)...);
+        }
+        else if (__n <= 1048576)
+        {
+            return __parallel_transform_reduce_mid_impl<_Tp, 256, 16, 1>(::std::forward<_ExecutionPolicy>(__exec), __n,
+                                                                         __reduce_op, __transform_op, __init,
+                                                                         ::std::forward<_Ranges>(__rngs)...);
+        }
         else if (__n <= 2097152)
         {
             return __parallel_transform_reduce_mid_impl<_Tp, 256, 32, 1>(::std::forward<_ExecutionPolicy>(__exec), __n,


### PR DESCRIPTION
Adds additional cases for reduce sizes between 8192 and 2097152. This allows the first kernel to use more threads in the GPU, while keeping the number of kernels executed to 2.