### PR TITLE
Refactored Scan_kt code

### DIFF
--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_scan.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_scan.h
@@ -126,8 +126,8 @@ single_pass_scan_impl(sycl::queue __queue, _InRange&& __in_rng, _OutRange&& __ou
     num_workitems = num_workitems + wgsize - 1;
     num_workitems -= (num_workitems % wgsize);
 
-    ::std::size_t num_wgs = num_workitems / wgsize;
     std::uint32_t elems_in_tile = wgsize * elems_per_workitem;
+    ::std::size_t num_wgs = oneapi::dpl::__internal::__dpl_ceiling_div(n, elems_in_tile);
 
     constexpr int status_flag_padding = SUBGROUP_SIZE;
     std::uint32_t status_flags_size = num_wgs + status_flag_padding + 1;
@@ -207,11 +207,11 @@ single_pass_scan_impl(sycl::queue __queue, _InRange&& __in_rng, _OutRange&& __ou
 }
 
 // The generic structure for configuring a kernel
-template <std::uint16_t _WorkGroupSize, std::uint16_t _ElemsPerWorkItem, typename _KernelName>
+template <std::uint16_t _ElemsPerWorkItem, std::uint16_t _WorkGroupSize, typename _KernelName>
 struct kernel_param
 {
-    static constexpr std::uint16_t __workgroup_size = _WorkGroupSize;
     static constexpr std::uint16_t __elems_per_workitem = _ElemsPerWorkItem;
+    static constexpr std::uint16_t __workgroup_size = _WorkGroupSize;
     using __kernel_name = _KernelName;
 };
 

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_scan.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_scan.h
@@ -118,8 +118,8 @@ single_pass_scan_impl(sycl::queue __queue, _InRange&& __in_rng, _OutRange&& __ou
 
     const ::std::size_t n = __in_rng.size();
 
-    constexpr ::std::size_t wgsize = _KernelParam::__workgroup_size;
-    constexpr ::std::size_t elems_per_workitem = _KernelParam::__elems_per_workitem;
+    constexpr ::std::size_t wgsize = _KernelParam::workgroup_size;
+    constexpr ::std::size_t elems_per_workitem = _KernelParam::elems_per_workitem;
 
     // Avoid non_uniform n by padding up to a multiple of wgsize
     ::std::size_t num_workitems = n / elems_per_workitem;
@@ -207,12 +207,12 @@ single_pass_scan_impl(sycl::queue __queue, _InRange&& __in_rng, _OutRange&& __ou
 }
 
 // The generic structure for configuring a kernel
-template <std::uint16_t _ElemsPerWorkItem, std::uint16_t _WorkGroupSize, typename _KernelName>
+template <std::uint16_t ElemsPerWorkItem, std::uint16_t WorkGroupSize, typename KernelName>
 struct kernel_param
 {
-    static constexpr std::uint16_t __elems_per_workitem = _ElemsPerWorkItem;
-    static constexpr std::uint16_t __workgroup_size = _WorkGroupSize;
-    using __kernel_name = _KernelName;
+    static constexpr std::uint16_t elems_per_workitem = ElemsPerWorkItem;
+    static constexpr std::uint16_t workgroup_size = WorkGroupSize;
+    using kernel_name = KernelName;
 };
 
 template <typename _KernelParam, typename _InIterator, typename _OutIterator, typename _BinaryOp>

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_scan.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_scan.h
@@ -122,12 +122,9 @@ single_pass_scan_impl(sycl::queue __queue, _InRange&& __in_rng, _OutRange&& __ou
     constexpr ::std::size_t elems_per_workitem = _KernelParam::elems_per_workitem;
 
     // Avoid non_uniform n by padding up to a multiple of wgsize
-    ::std::size_t num_workitems = n / elems_per_workitem;
-    num_workitems = num_workitems + wgsize - 1;
-    num_workitems -= (num_workitems % wgsize);
-
     std::uint32_t elems_in_tile = wgsize * elems_per_workitem;
     ::std::size_t num_wgs = oneapi::dpl::__internal::__dpl_ceiling_div(n, elems_in_tile);
+    ::std::size_t num_workitems = num_wgs * wgsize;
 
     constexpr int status_flag_padding = SUBGROUP_SIZE;
     std::uint32_t status_flags_size = num_wgs + status_flag_padding + 1;

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_scan.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_scan.h
@@ -217,8 +217,7 @@ struct kernel_param
 
 template <typename _KernelParam, typename _InIterator, typename _OutIterator, typename _BinaryOp>
 void
-single_pass_inclusive_scan(sycl::queue __queue, _InIterator __in_begin, _InIterator __in_end, _OutIterator __out_begin,
-                           _BinaryOp __binary_op)
+single_pass_inclusive_scan(sycl::queue __queue, _InIterator __in_begin, _InIterator __in_end, _OutIterator __out_begin, _BinaryOp __binary_op)
 {
     auto __n = __in_end - __in_begin;
 

--- a/test/parallel_api/numeric/numeric.ops/scan_kt.pass.cpp
+++ b/test/parallel_api/numeric/numeric.ops/scan_kt.pass.cpp
@@ -33,7 +33,7 @@ main()
         int* out_ptr = sycl::malloc_device<int>(n, q);
 
         q.copy(v.data(), in_ptr, n).wait();
-        using KernelParams = oneapi::dpl::experimental::kt::kernel_param<256, 8, class ScanKernel>;
+        using KernelParams = oneapi::dpl::experimental::kt::kernel_param<8, 128, class ScanKernel>;
         oneapi::dpl::experimental::kt::single_pass_inclusive_scan<KernelParams>(q, in_ptr, in_ptr+n, out_ptr, ::std::plus<int>());
 
         std::vector<int> tmp(n, 0);

--- a/test/parallel_api/numeric/numeric.ops/scan_kt.pass.cpp
+++ b/test/parallel_api/numeric/numeric.ops/scan_kt.pass.cpp
@@ -33,7 +33,7 @@ main()
         int* out_ptr = sycl::malloc_device<int>(n, q);
 
         q.copy(v.data(), in_ptr, n).wait();
-        using KernelParams = oneapi::dpl::experimental::kt::kernel_param<128, 2, class ScanKernel>;
+        using KernelParams = oneapi::dpl::experimental::kt::kernel_param<256, 8, class ScanKernel>;
         oneapi::dpl::experimental::kt::single_pass_inclusive_scan<KernelParams>(q, in_ptr, in_ptr+n, out_ptr, ::std::plus<int>());
 
         std::vector<int> tmp(n, 0);


### PR DESCRIPTION
- Changed number of workgroups calculation from next power of two to next multiple of wgsize
- Improved group_ballot by using the class member functions
- Using kernel_param struct to determine wgsize and elems per work item.