### PR TITLE
Scan_kt: Single memory allocation for device_memory

### DIFF
--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_scan.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_scan.h
@@ -208,12 +208,14 @@ single_pass_scan_impl(sycl::queue __queue, _InRange&& __in_rng, _OutRange&& __ou
         });
     });
 
-    __queue.submit(
+    auto free_event = __queue.submit(
         [=](sycl::handler& hdl)
         {
             hdl.depends_on(event);
             hdl.host_task([=](){ sycl::free(mem_pool, __queue); });
         });
+
+    free_event.wait();
 }
 
 // The generic structure for configuring a kernel

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_scan.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_scan.h
@@ -210,9 +210,12 @@ single_pass_scan_impl(sycl::queue __queue, _InRange&& __in_rng, _OutRange&& __ou
         });
     });
 
-    event.wait();
-
-    sycl::free(mem_pool, __queue);
+    __queue.submit(
+        [=](sycl::handler& hdl)
+        {
+            hdl.depends_on(event);
+            hdl.host_task([=](){ sycl::free(mem_pool, __queue); });
+        });
 }
 
 // The generic structure for configuring a kernel

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_scan.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_scan.h
@@ -133,7 +133,7 @@ single_pass_scan_impl(sycl::queue __queue, _InRange&& __in_rng, _OutRange&& __ou
     std::size_t tile_sums_elems = num_wgs + status_flag_padding;
     std::size_t tile_sums_size = status_flags_elems * sizeof(_Type);
 
-    std::size_t extra_mem_for_aligment = status_flags_size % alignof(_Type);
+    std::size_t extra_mem_for_aligment = alignof(_Type) - (status_flags_size % alignof(_Type));
     // status_flags_size for the status_flags
     // extra_mem_for_aligment of the datatype _Type
     // First tile_sums_size partial scanned values

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_scan.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_scan.h
@@ -131,7 +131,7 @@ single_pass_scan_impl(sycl::queue __queue, _InRange&& __in_rng, _OutRange&& __ou
     std::size_t status_flags_size = status_flags_elems * sizeof(std::uint32_t);
 
     std::size_t tile_sums_elems = num_wgs + status_flag_padding;
-    std::size_t tile_sums_size = status_flags_elems * sizeof(std::uint32_t);
+    std::size_t tile_sums_size = status_flags_elems * sizeof(_Type);
 
     std::size_t extra_mem_for_aligment = status_flags_size % alignof(_Type);
     // status_flags_size for the status_flags

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_scan.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_scan.h
@@ -215,7 +215,7 @@ single_pass_scan_impl(sycl::queue __queue, _InRange&& __in_rng, _OutRange&& __ou
             hdl.host_task([=](){ sycl::free(mem_pool, __queue); });
         });
 
-    free_event.wait();
+    event.wait();
 }
 
 // The generic structure for configuring a kernel

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_scan.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_scan.h
@@ -35,7 +35,8 @@ struct __scan_status_flag
 
     static constexpr int padding = SUBGROUP_SIZE;
 
-    __scan_status_flag(const std::uint32_t tile_id, std::uint32_t* flags_begin, _T* tile_sums, size_t num_elements)
+    __scan_status_flag(const std::uint32_t tile_id, std::uint32_t* flags_begin, _T* tile_sums,
+                       size_t num_elements)
         : atomic_flag(*(flags_begin + tile_id + padding)), scanned_partial_value(tile_sums + tile_id + padding),
           scanned_full_value(tile_sums + tile_id + padding + num_elements), num_elements{num_elements}
     {
@@ -99,9 +100,6 @@ struct __scan_status_flag
 
         return sum;
     }
-
-    std::uint32_t* flags_begin;
-    _T* tile_sums;
 
     _AtomicRefT atomic_flag;
     _T* scanned_partial_value;


### PR DESCRIPTION
Unifies all the device memory allocation in a single call.