### PR TITLE
Scan_kt: async free of the device memory

### DIFF
--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_scan.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_scan.h
@@ -211,10 +211,10 @@ single_pass_scan_impl(sycl::queue __queue, _InRange&& __in_rng, _OutRange&& __ou
     });
 
     __queue.submit(
-        [&](sycl::handler& hdl)
+        [=](sycl::handler& hdl)
         {
             hdl.depends_on(event);
-            hdl.host_task([&](){ sycl::free(mem_pool, __queue); });
+            hdl.host_task([=](){ sycl::free(mem_pool, __queue); });
         });
 }
 

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_scan.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_scan.h
@@ -210,9 +210,12 @@ single_pass_scan_impl(sycl::queue __queue, _InRange&& __in_rng, _OutRange&& __ou
         });
     });
 
-    event.wait();
-
-    sycl::free(mem_pool, __queue);
+    __queue.submit(
+        [&](sycl::handler& hdl)
+        {
+            hdl.depends_on(event);
+            hdl.host_task([&](){ sycl::free(mem_pool, __queue); });
+        });
 }
 
 // The generic structure for configuring a kernel


### PR DESCRIPTION
This change avoids waiting for the memory deallocation before exiting the kernel