### PR TITLE
Atomic64 flags + value implementation

### DIFF
--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_scan.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_scan.h
@@ -26,11 +26,13 @@ inline namespace igpu {
 
 constexpr ::std::size_t SUBGROUP_SIZE = 32;
 
-template <typename Type, template <typename> typename LoopbackScanMemory, typename TileId>
+template <typename Type, typename UseAtomic64, template <typename, typename> typename LoopbackScanMemory,
+          typename TileId>
 struct ScanMemoryManager
 {
     using _TileIdT = typename TileId::_TileIdT;
-    using _FlagT = typename LoopbackScanMemory<Type>::_FlagT;
+    using _LoopbackScanMemory = LoopbackScanMemory<Type, UseAtomic64>;
+    using _FlagT = typename _LoopbackScanMemory::_FlagT;
 
     ScanMemoryManager(sycl::queue q) : q{q} {};
 
@@ -49,7 +51,7 @@ struct ScanMemoryManager
     void
     allocate(::std::size_t num_wgs)
     {
-        ::std::size_t scan_memory_size = LoopbackScanMemory<Type>::get_memory_size(num_wgs);
+        ::std::size_t scan_memory_size = _LoopbackScanMemory::get_memory_size(num_wgs);
         constexpr ::std::size_t padded_tileid_size = TileId::get_padded_memory_size();
         constexpr ::std::size_t tileid_size = TileId::get_memory_size();
 
@@ -85,8 +87,11 @@ struct ScanMemoryManager
     sycl::queue q;
 };
 
+template <typename _T, typename UseAtomic64>
+struct LoopbackScanMemory;
+
 template <typename _T>
-struct LoopbackScanMemory
+struct LoopbackScanMemory<_T, /* UseAtomic64=*/::std::false_type>
 {
     using _FlagT = ::std::uint32_t;
     using _AtomicFlagRefT = sycl::atomic_ref<_FlagT, sycl::memory_order::acq_rel, sycl::memory_scope::device,
@@ -214,6 +219,116 @@ struct LoopbackScanMemory
     _T* tile_values_begin;
 };
 
+template <typename _T>
+struct LoopbackScanMemory<_T, /* UseAtomic64=*/::std::true_type>
+{
+    using _FlagT = ::std::uint64_t;
+    using _AtomicFlagRefT = sycl::atomic_ref<_FlagT, sycl::memory_order::relaxed, sycl::memory_scope::device,
+                                             sycl::access::address_space::global_space>;
+
+    // Each flag is divided in 2 32bit values
+    // 32..63 status bits
+    // 00..31 value bits
+    // Example: status = full scanned value, int value = 15:
+    // 1000 0000 0000 0000 0000 0000 0000 0000 | 0000 0000 0000 0000 0000 0000 0000 1111
+
+    // Status values:
+    // 00xxxx - not computed
+    // 01xxxx - partial
+    // 10xxxx - full
+    // 110000 - out of bounds
+
+    static constexpr _FlagT NOT_READY = 0;
+    static constexpr _FlagT PARTIAL_MASK = 1l << (sizeof(_FlagT) * 8 - 2);
+    static constexpr _FlagT FULL_MASK = 1l << (sizeof(_FlagT) * 8 - 1);
+    static constexpr _FlagT OUT_OF_BOUNDS = PARTIAL_MASK | FULL_MASK;
+
+    static constexpr _FlagT VALUE_MASK = (1l << sizeof(::std::uint32_t) * 8) - 1; // 32bit-mask to store value
+
+    static constexpr ::std::size_t padding = SUBGROUP_SIZE;
+
+    LoopbackScanMemory(::std::uint8_t* scan_memory_begin, ::std::size_t num_wgs)
+        : num_elements(get_num_elements(num_wgs))
+    {
+        // LoopbackScanMemory: [Partial Value, ..., Full Value, ..., Flag, ...]
+        // Each section has num_wgs + padding elements
+        flags_begin = get_flags_begin(scan_memory_begin, num_wgs);
+    }
+
+    void
+    set_partial(::std::size_t tile_id, _T val)
+    {
+        _AtomicFlagRefT atomic_flag(*(flags_begin + tile_id + padding));
+
+        atomic_flag.store(PARTIAL_MASK | static_cast<::std::uint32_t>(val));
+    }
+
+    void
+    set_full(::std::size_t tile_id, _T val)
+    {
+        _AtomicFlagRefT atomic_flag(*(flags_begin + tile_id + padding));
+
+        atomic_flag.store(FULL_MASK | static_cast<::std::uint32_t>(val));
+    }
+
+    _FlagT
+    load_flag(::std::size_t tile_id) const
+    {
+        _AtomicFlagRefT atomic_flag(*(flags_begin + tile_id + padding));
+
+        return atomic_flag.load();
+    }
+
+    _T
+    get_value(::std::size_t, _FlagT flag) const
+    {
+        return static_cast<::std::uint32_t>(flag & VALUE_MASK);
+    }
+
+    static _FlagT*
+    get_flags_begin(::std::uint8_t* scan_memory_begin, ::std::size_t)
+    {
+        return reinterpret_cast<_FlagT*>(scan_memory_begin);
+    }
+
+    static ::std::size_t
+    get_memory_size(::std::size_t num_wgs)
+    {
+        ::std::size_t num_elements = get_num_elements(num_wgs);
+        return num_elements * sizeof(_FlagT);
+    }
+
+    static ::std::size_t
+    get_num_elements(::std::size_t num_wgs)
+    {
+        return padding + num_wgs;
+    }
+
+    static bool
+    is_ready(_FlagT flag)
+    {
+        // flag & OUT_OF_BOUNDS != NOT_READY means it has either partial or full value, or is out of bounds
+        return (flag & OUT_OF_BOUNDS) != NOT_READY;
+    }
+
+    static bool
+    is_full(_FlagT flag)
+    {
+        return (flag & OUT_OF_BOUNDS) == FULL_MASK;
+    }
+
+    static bool
+    is_out_of_bounds(_FlagT flag)
+    {
+        return (flag & OUT_OF_BOUNDS) == OUT_OF_BOUNDS;
+    }
+
+  private:
+    ::std::size_t num_elements;
+    _FlagT* flags_begin;
+    _T* tile_values_begin;
+};
+
 struct TileId
 {
     using _TileIdT = ::std::uint32_t;
@@ -248,11 +363,14 @@ struct TileId
 struct cooperative_lookback
 {
 
-    template <typename _T, typename _Subgroup, typename BinOp, template <typename> typename LoopbackScanMemory>
+    template <typename _T, typename _Subgroup, typename BinOp,
+              template <typename, typename> typename LoopbackScanMemory, typename UseAtomic64>
     _T
-    operator()(std::uint32_t tile_id, const _Subgroup& subgroup, BinOp bin_op, LoopbackScanMemory<_T> memory)
+    operator()(std::uint32_t tile_id, const _Subgroup& subgroup, BinOp bin_op,
+               LoopbackScanMemory<_T, UseAtomic64> memory)
     {
-        using FlagT = typename LoopbackScanMemory<_T>::_FlagT;
+        using _LoopbackScanMemory = LoopbackScanMemory<_T, UseAtomic64>;
+        using FlagT = typename _LoopbackScanMemory::_FlagT;
 
         _T sum = 0;
         int offset = -1;
@@ -265,14 +383,14 @@ struct cooperative_lookback
             do
             {
                 flag = memory.load_flag(tile - local_id);
-            } while (!sycl::all_of_group(subgroup, LoopbackScanMemory<_T>::is_ready(flag))); // Loop till all ready
+            } while (!sycl::all_of_group(subgroup, _LoopbackScanMemory::is_ready(flag))); // Loop till all ready
 
-            bool is_full = LoopbackScanMemory<_T>::is_full(flag);
+            bool is_full = _LoopbackScanMemory::is_full(flag);
             auto is_full_ballot = sycl::ext::oneapi::group_ballot(subgroup, is_full);
             auto lowest_item_with_full = is_full_ballot.find_low();
 
             // TODO: Use identity_fn for out of bounds values
-            _T contribution = local_id <= lowest_item_with_full && !LoopbackScanMemory<_T>::is_out_of_bounds(flag)
+            _T contribution = local_id <= lowest_item_with_full && !_LoopbackScanMemory::is_out_of_bounds(flag)
                                   ? memory.get_value(tile - local_id, flag)
                                   : _T{0};
 
@@ -291,56 +409,55 @@ struct cooperative_lookback
     }
 };
 
-template <typename _KernelParam, bool _Inclusive, typename _InRange, typename _OutRange, typename _BinaryOp>
+template <typename _KernelParam, typename _Inclusive, typename _UseAtomic64, typename _InRange, typename _OutRange,
+          typename _BinaryOp>
 void
 single_pass_scan_impl(sycl::queue __queue, _InRange&& __in_rng, _OutRange&& __out_rng, _BinaryOp __binary_op)
 {
     using _Type = oneapi::dpl::__internal::__value_t<_InRange>;
     using _TileIdT = TileId::_TileIdT;
-    using _FlagT = typename LoopbackScanMemory<_Type>::_FlagT;
+    using _LoopBackScanMemory = LoopbackScanMemory<_Type, _UseAtomic64>;
+    using _FlagT = typename _LoopBackScanMemory::_FlagT;
 
-    static_assert(_Inclusive, "Single-pass scan only available for inclusive scan");
+    static_assert(std::is_same_v<_Inclusive, ::std::true_type>, "Single-pass scan only available for inclusive scan");
 
     const ::std::size_t n = __in_rng.size();
 
     constexpr ::std::size_t wgsize = _KernelParam::workgroup_size;
     constexpr ::std::size_t elems_per_workitem = _KernelParam::elems_per_workitem;
-
     // Avoid non_uniform n by padding up to a multiple of wgsize
     ::std::uint32_t elems_in_tile = wgsize * elems_per_workitem;
     ::std::size_t num_wgs = oneapi::dpl::__internal::__dpl_ceiling_div(n, elems_in_tile);
     ::std::size_t num_workitems = num_wgs * wgsize;
 
-    ScanMemoryManager<_Type, LoopbackScanMemory, TileId> scratch(__queue);
+    ScanMemoryManager<_Type, _UseAtomic64, LoopbackScanMemory, TileId> scratch(__queue);
     scratch.allocate(num_wgs);
 
     // Memory Structure:
     // [Loopback Scan Memory, Tile Id Counter]
     auto scan_memory_begin = scratch.scan_memory_ptr();
-    auto status_flags_begin = LoopbackScanMemory<_Type>::get_flags_begin(scan_memory_begin, num_wgs);
+    auto status_flags_begin = _LoopBackScanMemory::get_flags_begin(scan_memory_begin, num_wgs);
     auto tile_id_begin = scratch.tile_id_ptr();
 
-    ::std::size_t num_elements = LoopbackScanMemory<_Type>::get_num_elements(num_wgs);
+    ::std::size_t num_elements = _LoopBackScanMemory::get_num_elements(num_wgs);
     // fill_num_wgs num_elements + 1 to also initialize tile_id_counter
     ::std::size_t fill_num_wgs = oneapi::dpl::__internal::__dpl_ceiling_div(num_elements + 1, wgsize);
 
     auto fill_event = __queue.submit(
         [&](sycl::handler& hdl)
         {
-            hdl.parallel_for<class scan_kt_init>(sycl::nd_range<1>{fill_num_wgs * wgsize, wgsize},
-                                                 [=](const sycl::nd_item<1>& item)
-                                                 {
-                                                     int id = item.get_global_linear_id();
-                                                     if (id < num_elements)
-                                                         status_flags_begin[id] =
-                                                             id < LoopbackScanMemory<_Type>::padding
-                                                                 ? LoopbackScanMemory<_Type>::OUT_OF_BOUNDS
-                                                                 : LoopbackScanMemory<_Type>::NOT_READY;
-                                                     if (id == num_elements)
-                                                         tile_id_begin[0] = 0;
-                                                 });
+            hdl.parallel_for(sycl::nd_range<1>{fill_num_wgs * wgsize, wgsize},
+                             [=](const sycl::nd_item<1>& item)
+                             {
+                                 int id = item.get_global_linear_id();
+                                 if (id < num_elements)
+                                     status_flags_begin[id] = id < _LoopBackScanMemory::padding
+                                                                  ? _LoopBackScanMemory::OUT_OF_BOUNDS
+                                                                  : _LoopBackScanMemory::NOT_READY;
+                                 if (id == num_elements)
+                                     tile_id_begin[0] = 0;
+                             });
         });
-
 
     auto event = __queue.submit([&](sycl::handler& hdl) {
         auto tile_id_lacc = sycl::local_accessor<std::uint32_t, 1>(sycl::range<1>{1}, hdl);
@@ -348,67 +465,75 @@ single_pass_scan_impl(sycl::queue __queue, _InRange&& __in_rng, _OutRange&& __ou
         hdl.depends_on(fill_event);
 
         oneapi::dpl::__ranges::__require_access(hdl, __in_rng, __out_rng);
-        hdl.parallel_for<class scan_kt_main>(sycl::nd_range<1>(num_workitems, wgsize), [=](const sycl::nd_item<1>& item)  [[intel::reqd_sub_group_size(SUBGROUP_SIZE)]] {
-            auto group = item.get_group();
-            auto local_id = item.get_local_id(0);
-            auto stride = item.get_local_range(0);
-            auto subgroup = item.get_sub_group();
+        hdl.parallel_for(sycl::nd_range<1>(num_workitems, wgsize),
+                         [=](const sycl::nd_item<1>& item) [[intel::reqd_sub_group_size(SUBGROUP_SIZE)]]
+                         {
+                             auto group = item.get_group();
+                             auto local_id = item.get_local_id(0);
+                             auto stride = item.get_local_range(0);
+                             auto subgroup = item.get_sub_group();
 
-            // Obtain unique ID for this work-group that will be used in decoupled lookback
-            TileId dynamic_tile_id(tile_id_begin);
-            if (group.leader())
-            {
-                tile_id_lacc[0] = dynamic_tile_id.fetch_inc();
-            }
-            sycl::group_barrier(group);
-            std::uint32_t tile_id = tile_id_lacc[0];
+                             // Obtain unique ID for this work-group that will be used in decoupled lookback
+                             TileId dynamic_tile_id(tile_id_begin);
+                             if (group.leader())
+                             {
+                                 tile_id_lacc[0] = dynamic_tile_id.fetch_inc();
+                             }
+                             sycl::group_barrier(group);
+                             std::uint32_t tile_id = tile_id_lacc[0];
 
-            // Global load into local
-            auto wg_current_offset = (tile_id*elems_in_tile);
-            auto wg_next_offset = ((tile_id+1)*elems_in_tile);
-            size_t wg_local_memory_size = elems_in_tile;
-            if (wg_current_offset >= n)
-                return;
-            if (wg_next_offset > n)
-                wg_local_memory_size = n - wg_current_offset;
+                             // Global load into local
+                             auto wg_current_offset = (tile_id * elems_in_tile);
+                             auto wg_next_offset = ((tile_id + 1) * elems_in_tile);
+                             size_t wg_local_memory_size = elems_in_tile;
+                             if (wg_current_offset >= n)
+                                 return;
+                             if (wg_next_offset > n)
+                                 wg_local_memory_size = n - wg_current_offset;
 
-            if (wg_next_offset <= n) {
-                _ONEDPL_PRAGMA_UNROLL
-                for (std::uint32_t i = 0; i < elems_per_workitem; ++i)
-                    tile_vals[local_id + stride * i] = __in_rng[wg_current_offset + local_id + stride * i];
-            } else {
-                for (std::uint32_t i = 0; i < elems_per_workitem; ++i) {
-                    if (wg_current_offset + local_id + stride * i < n)
-                        tile_vals[local_id + stride * i] = __in_rng[wg_current_offset + local_id + stride * i];
-                }
-            }
-            sycl::group_barrier(group);
+                             if (wg_next_offset <= n)
+                             {
+                                 _ONEDPL_PRAGMA_UNROLL
+                                 for (std::uint32_t i = 0; i < elems_per_workitem; ++i)
+                                     tile_vals[local_id + stride * i] =
+                                         __in_rng[wg_current_offset + local_id + stride * i];
+                             }
+                             else
+                             {
+                                 for (std::uint32_t i = 0; i < elems_per_workitem; ++i)
+                                 {
+                                     if (wg_current_offset + local_id + stride * i < n)
+                                         tile_vals[local_id + stride * i] =
+                                             __in_rng[wg_current_offset + local_id + stride * i];
+                                 }
+                             }
+                             sycl::group_barrier(group);
 
-            auto in_begin = tile_vals.template get_multi_ptr<sycl::access::decorated::no>().get();
-            auto in_end = in_begin + wg_local_memory_size;
-            auto out_begin = __out_rng.begin() + wg_current_offset;
+                             auto in_begin = tile_vals.template get_multi_ptr<sycl::access::decorated::no>().get();
+                             auto in_end = in_begin + wg_local_memory_size;
+                             auto out_begin = __out_rng.begin() + wg_current_offset;
 
-            auto local_sum = sycl::joint_reduce(group, in_begin, in_end, __binary_op);
-            _Type prev_sum = 0;
+                             auto local_sum = sycl::joint_reduce(group, in_begin, in_end, __binary_op);
+                             _Type prev_sum = 0;
 
-            // The first sub-group will query the previous tiles to find a prefix
-            if (subgroup.get_group_id() == 0)
-            {
-                LoopbackScanMemory<_Type> scan_mem(scan_memory_begin, num_wgs);
+                             // The first sub-group will query the previous tiles to find a prefix
+                             if (subgroup.get_group_id() == 0)
+                             {
+                                 _LoopBackScanMemory scan_mem(scan_memory_begin, num_wgs);
 
-                if (group.leader())
-                    scan_mem.set_partial(tile_id, local_sum);
+                                 if (group.leader())
+                                     scan_mem.set_partial(tile_id, local_sum);
 
-                // Find lowest work-item that has a full result (if any) and sum up subsequent partial results to obtain this tile's exclusive sum
-                prev_sum = cooperative_lookback()(tile_id, subgroup, __binary_op, scan_mem);
+                                 // Find lowest work-item that has a full result (if any) and sum up subsequent partial results to obtain this tile's exclusive sum
+                                 prev_sum = cooperative_lookback()(tile_id, subgroup, __binary_op, scan_mem);
 
-                if (group.leader())
-                    scan_mem.set_full(tile_id, prev_sum + local_sum);
-            }
+                                 if (group.leader())
+                                     scan_mem.set_full(tile_id, prev_sum + local_sum);
+                             }
 
-            prev_sum = sycl::group_broadcast(group, prev_sum, 0);
-            sycl::joint_inclusive_scan(group, in_begin, in_end, out_begin, __binary_op, prev_sum);
-        });
+                             prev_sum = sycl::group_broadcast(group, prev_sum, 0);
+                             sycl::joint_inclusive_scan(group, in_begin, in_end, out_begin, __binary_op, prev_sum);
+                         });
     });
 
     scratch.async_free(event);
@@ -438,7 +563,13 @@ single_pass_inclusive_scan(sycl::queue __queue, _InIterator __in_begin, _InItera
         oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::write, _OutIterator>();
     auto __buf2 = __keep2(__out_begin, __out_begin + __n);
 
-    single_pass_scan_impl<_KernelParam, true>(__queue, __buf1.all_view(), __buf2.all_view(), __binary_op);
+    if (__queue.get_device().has(sycl::aspect::atomic64) &&
+        sizeof(typename std::iterator_traits<_InIterator>::value_type) <= sizeof(std::uint32_t))
+        single_pass_scan_impl<_KernelParam, /* Inclusive */ std::true_type, /* UseAtomic64 */ std::true_type>(
+            __queue, __buf1.all_view(), __buf2.all_view(), __binary_op);
+    else
+        single_pass_scan_impl<_KernelParam, /* Inclusive */ std::true_type, /* UseAtomic64 */ std::false_type>(
+            __queue, __buf1.all_view(), __buf2.all_view(), __binary_op);
 }
 
 } // inline namespace igpu


### PR DESCRIPTION
This PR introduces a specialization of the LoopbackScanMemory to unify flags and memory under the same 64 bit variable.
It's expected to work for 32 bit implementations.