### PR TITLE
Various small performance improvements to scan_kt

### DIFF
--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_scan.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_scan.h
@@ -386,8 +386,7 @@ struct cooperative_lookback
                                   : _T{0};
 
             // Sum all of the partial results from the tiles found, as well as the full contribution from the closest tile (if any)
-            sum += sycl::reduce_over_group(subgroup, contribution, bin_op);
-
+            sum = bin_op(sum, contribution);
             // If we found a full value, we can stop looking at previous tiles. Otherwise,
             // keep going through tiles until we either find a full tile or we've completely
             // recomputed the prefix using partial values
@@ -395,6 +394,7 @@ struct cooperative_lookback
                 break;
 
         }
+        sum = sycl::reduce_over_group(subgroup, sum, bin_op);
 
         return sum;
     }

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_scan.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_scan.h
@@ -274,7 +274,7 @@ struct LookbackScanMemory<_T, /* UseAtomic64=*/::std::true_type>
     _T
     get_value(::std::size_t, _FlagT flag) const
     {
-        return static_cast<::std::uint32_t>(flag & VALUE_MASK);
+        return static_cast<_T>(flag & VALUE_MASK);
     }
 
     static _FlagT*

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_scan.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_scan.h
@@ -489,6 +489,7 @@ single_pass_scan_impl(sycl::queue __queue, _InRange&& __in_rng, _OutRange&& __ou
 
                              if (wg_next_offset > n)
                                  wg_local_memory_size = n - wg_current_offset;
+                             //TODO: assumes default ctor produces identity w.r.t. __binary_op
                              _Type my_reducer{};
                              if (wg_next_offset <= n)
                              {

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_scan.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_scan.h
@@ -537,6 +537,7 @@ single_pass_scan_impl(sycl::queue __queue, _InRange&& __in_rng, _OutRange&& __ou
                              }
 
                              _Type carry = sycl::group_broadcast(group, prev_sum, 0);
+                             // TODO: Find a fix for _ONEDPL_PRAGMA_UNROLL
                              #pragma unroll
                              for (::std::uint32_t step = 0; step < elems_per_workitem; ++step)
                              {


### PR DESCRIPTION
Quite a bit going on here:
 - Disabled the dynamic tile id by default (though for now we still allocate & initialize the counter)
 - Change (and constexpr) some types
 - Unroll some loops (TODO: we need to fix _ONEDPL_PRAGMA_UNROLL)
 - Reduce from registers, not local mem
 - Unrolled joint_inclusive_scan
 - Defer reduce_over_group to end of lookback loop