### PR TITLE
Unified scratch allocation (or host USM)

### DIFF
--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce.h
@@ -117,23 +117,22 @@ struct __parallel_transform_reduce_small_submitter<_Tp, __work_group_size, __ite
 
         const _Size __n_items = oneapi::dpl::__internal::__dpl_ceiling_div(__n, __iters_per_work_item);
 
-        __usm_host_or_buffer_storage<_ExecutionPolicy, _Tp> __res_container(__exec, 1);
+        __usm_host_or_unified_storage<_ExecutionPolicy, _Tp> __scratch_container(__exec, 0);
 
         sycl::event __reduce_event = __exec.queue().submit([&, __n](sycl::handler& __cgh) {
             oneapi::dpl::__ranges::__require_access(__cgh, __rngs...); // get an access to data under SYCL buffer
-            auto __res_acc = __res_container.__get_acc(__cgh);
+            auto __res_ptr = __scratch_container.__get_result_ptr();
             ::std::size_t __local_mem_size = __reduce_pattern.local_mem_req(__work_group_size);
             __dpl_sycl::__local_accessor<_Tp> __temp_local(sycl::range<1>(__local_mem_size), __cgh);
             __cgh.parallel_for<_Name...>(
                 sycl::nd_range<1>(sycl::range<1>(__work_group_size), sycl::range<1>(__work_group_size)),
                 [=](sycl::nd_item<1> __item_id) {
-                    auto __res_ptr = __res_acc.__get_pointer();
                     __work_group_reduce_kernel<_Tp>(__item_id, __n, __transform_pattern, __reduce_pattern, __init,
                                                     __temp_local, __res_ptr, __rngs...);
                 });
         });
 
-        return __future(__reduce_event, __res_container);
+        return __future(__reduce_event, __scratch_container);
     }
 }; // struct __parallel_transform_reduce_small_submitter
 
@@ -172,7 +171,7 @@ struct __parallel_transform_reduce_device_kernel_submitter<_Tp, __work_group_siz
               typename... _Ranges>
     auto
     operator()(_ExecutionPolicy&& __exec, _Size __n, _ReduceOp __reduce_op, _TransformOp __transform_op,
-               _InitType __init, sycl::buffer<_Tp>& __temp, _Ranges&&... __rngs) const
+               _InitType __init, _Tp* __temp_ptr, _Ranges&&... __rngs) const
     {
         auto __transform_pattern =
             unseq_backend::transform_reduce<_ExecutionPolicy, __iters_per_work_item, _ReduceOp, _TransformOp, _Tp,
@@ -185,14 +184,13 @@ struct __parallel_transform_reduce_device_kernel_submitter<_Tp, __work_group_siz
 
         return __exec.queue().submit([&, __n](sycl::handler& __cgh) {
             oneapi::dpl::__ranges::__require_access(__cgh, __rngs...); // get an access to data under SYCL buffer
-            sycl::accessor __temp_acc{__temp, __cgh, sycl::write_only, __dpl_sycl::__no_init{}};
             ::std::size_t __local_mem_size = __reduce_pattern.local_mem_req(__work_group_size);
             __dpl_sycl::__local_accessor<_Tp> __temp_local(sycl::range<1>(__local_mem_size), __cgh);
             __cgh.parallel_for<_KernelName...>(
                 sycl::nd_range<1>(sycl::range<1>(__n_groups * __work_group_size), sycl::range<1>(__work_group_size)),
                 [=](sycl::nd_item<1> __item_id) {
                     __device_reduce_kernel<_Tp>(__item_id, __n, __transform_pattern, __reduce_pattern, __temp_local,
-                                                __temp_acc, __rngs...);
+                                                __temp_ptr, __rngs...);
                 });
         });
     }
@@ -214,13 +212,17 @@ struct __parallel_transform_reduce_work_group_kernel_submitter<
               oneapi::dpl::__internal::__enable_if_device_execution_policy<_ExecutionPolicy, int> = 0>
     auto
     operator()(_ExecutionPolicy&& __exec, sycl::event& __reduce_event, _Size __n, _ReduceOp __reduce_op,
-               _TransformOp __transform_op, _InitType __init, sycl::buffer<_Tp>& __temp) const
+               _TransformOp __transform_op, _InitType __init,
+               __usm_host_or_unified_storage<_ExecutionPolicy, _Tp> __scratch_container) const
     {
         using _NoOpFunctor = unseq_backend::walk_n<_ExecutionPolicy, oneapi::dpl::__internal::__no_op>;
         auto __transform_pattern =
             unseq_backend::transform_reduce<_ExecutionPolicy, __iters_per_work_item, _ReduceOp, _NoOpFunctor, _Tp,
                                             _Commutative>{__reduce_op, _NoOpFunctor{}};
         auto __reduce_pattern = unseq_backend::reduce_over_group<_ExecutionPolicy, _ReduceOp, _Tp>{__reduce_op};
+
+        _Tp* __temp_ptr = __scratch_container.__get_scratch_ptr();
+        _Tp* __res_ptr = __scratch_container.__get_result_ptr();
 
         // Lower the work group size of the second kernel to the next power of 2 if __n < __work_group_size.
         auto __work_group_size2 = __work_group_size;
@@ -234,26 +236,21 @@ struct __parallel_transform_reduce_work_group_kernel_submitter<
             }
         }
 
-        __usm_host_or_buffer_storage<_ExecutionPolicy, _Tp> __res_container(__exec, 1);
-
         __reduce_event = __exec.queue().submit([&, __n](sycl::handler& __cgh) {
             __cgh.depends_on(__reduce_event);
 
-            sycl::accessor __temp_acc{__temp, __cgh, sycl::read_only};
-            auto __res_acc = __res_container.__get_acc(__cgh);
             ::std::size_t __local_mem_size2 = __reduce_pattern.local_mem_req(__work_group_size2);
             __dpl_sycl::__local_accessor<_Tp> __temp_local(sycl::range<1>(__local_mem_size2), __cgh);
 
             __cgh.parallel_for<_KernelName...>(
                 sycl::nd_range<1>(sycl::range<1>(__work_group_size2), sycl::range<1>(__work_group_size2)),
                 [=](sycl::nd_item<1> __item_id) {
-                    auto __res_ptr = __res_acc.__get_pointer();
                     __work_group_reduce_kernel<_Tp>(__item_id, __n, __transform_pattern, __reduce_pattern, __init,
-                                                    __temp_local, __res_ptr, __temp_acc);
+                                                    __temp_local, __res_ptr, __temp_ptr);
                 });
         });
 
-        return __future(__reduce_event, __res_container);
+        return __future(__reduce_event, __scratch_container);
     }
 }; // struct __parallel_transform_reduce_work_group_kernel_submitter
 
@@ -279,17 +276,18 @@ __parallel_transform_reduce_mid_impl(_ExecutionPolicy&& __exec, _Size __n, _Redu
     // number of buffer elements processed within workgroup
     constexpr _Size __size_per_work_group = __iters_per_work_item_device_kernel * __work_group_size;
     const _Size __n_groups = oneapi::dpl::__internal::__dpl_ceiling_div(__n, __size_per_work_group);
-    sycl::buffer<_Tp> __temp{sycl::range<1>(__n_groups)};
+    __usm_host_or_unified_storage<_ExecutionPolicy, _Tp> __scratch_container(__exec, __n_groups);
 
     sycl::event __reduce_event =
         __parallel_transform_reduce_device_kernel_submitter<_Tp, __work_group_size, __iters_per_work_item_device_kernel,
                                                             _Commutative, _ReduceDeviceKernel>()(
-            __exec, __n, __reduce_op, __transform_op, __init, __temp, ::std::forward<_Ranges>(__rngs)...);
+            __exec, __n, __reduce_op, __transform_op, __init, __scratch_container.__get_scratch_ptr(),
+            ::std::forward<_Ranges>(__rngs)...);
 
     __n = __n_groups; // Number of preliminary results from the device kernel.
     return __parallel_transform_reduce_work_group_kernel_submitter<
         _Tp, __work_group_size, __iters_per_work_item_work_group_kernel, _Commutative, _ReduceWorkGroupKernel>()(
-        ::std::forward<_ExecutionPolicy>(__exec), __reduce_event, __n, __reduce_op, __transform_op, __init, __temp);
+        ::std::forward<_ExecutionPolicy>(__exec), __reduce_event, __n, __reduce_op, __transform_op, __init, __scratch_container);
 }
 
 // General implementation using a tree reduction
@@ -329,8 +327,10 @@ struct __parallel_transform_reduce_impl
         _Size __n_items = oneapi::dpl::__internal::__dpl_ceiling_div(__n, __iters_per_work_item);
 
         // Create temporary global buffers to store temporary values
-        sycl::buffer<_Tp> __temp(sycl::range<1>(2 * __n_groups));
-        __usm_host_or_buffer_storage<_ExecutionPolicy, _Tp> __res_container(__exec, 1);
+        __usm_host_or_unified_storage<_ExecutionPolicy, _Tp> __scratch_container(__exec, 2 * __n_groups);
+        _Tp* __temp_ptr = __scratch_container.__get_scratch_ptr();
+        _Tp* __res_ptr = __scratch_container.__get_result_ptr();
+
         // __is_first == true. Reduce over each work_group
         // __is_first == false. Reduce between work groups
         bool __is_first = true;
@@ -349,8 +349,6 @@ struct __parallel_transform_reduce_impl
 
                     // get an access to data under SYCL buffer
                     oneapi::dpl::__ranges::__require_access(__cgh, __rngs...);
-                    sycl::accessor __temp_acc{__temp, __cgh, sycl::read_write};
-                    auto __res_acc = __res_container.__get_acc(__cgh);
                     ::std::size_t __local_mem_size = __reduce_pattern.local_mem_req(__work_group_size);
                     __dpl_sycl::__local_accessor<_Tp> __temp_local(sycl::range<1>(__local_mem_size), __cgh);
 #if _ONEDPL_COMPILE_KERNEL && _ONEDPL_KERNEL_BUNDLE_PRESENT
@@ -363,7 +361,6 @@ struct __parallel_transform_reduce_impl
                         sycl::nd_range<1>(sycl::range<1>(__n_groups * __work_group_size),
                                           sycl::range<1>(__work_group_size)),
                         [=](sycl::nd_item<1> __item_id) {
-                            auto __res_ptr = __res_acc.__get_pointer();
                             auto __local_idx = __item_id.get_local_id(0);
                             auto __group_idx = __item_id.get_group(0);
 
@@ -372,7 +369,7 @@ struct __parallel_transform_reduce_impl
                             if (__is_first)
                                 __result = __transform_pattern1(__item_id, __n, /*global_offset*/ (_Size)0, __rngs...);
                             else
-                                __result = __transform_pattern2(__item_id, __n, __offset_2, __temp_acc);
+                                __result = __transform_pattern2(__item_id, __n, __offset_2, __temp_ptr);
                             // 2. Reduce within work group
                             __result = __reduce_pattern(__item_id, __n_items, __result, __temp_local);
                             if (__local_idx == 0)
@@ -384,10 +381,10 @@ struct __parallel_transform_reduce_impl
                                     __res_ptr[0] = __result;
                                 }
 
-                                __temp_acc[__offset_1 + __group_idx] = __result;
+                                __temp_ptr[__offset_1 + __group_idx] = __result;
                             }
 
-                            __temp_acc[__offset_1 + __group_idx] = __result;
+                            __temp_ptr[__offset_1 + __group_idx] = __result;
                     });
             });
             __is_first = false;
@@ -397,7 +394,7 @@ struct __parallel_transform_reduce_impl
             __n_groups = oneapi::dpl::__internal::__dpl_ceiling_div(__n, __size_per_work_group);
         } while (__n > 1);
 
-        return __future(__reduce_event, __res_container);
+        return __future(__reduce_event, __scratch_container);
     }
 }; // struct __parallel_transform_reduce_impl
 

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
@@ -265,10 +265,10 @@ struct transform_reduce
     inline _Tp
     operator()(const _NDItemId& __item_id, const _Size& __n, const _Size& __global_offset, const _Acc&... __acc) const
     {
-#ifndef __SPIRV__
+#ifndef _ONEDPL_DETECT_SPIRV_COMPILATION
         if constexpr (_Commutative::value)
             return nonseq_impl(__item_id, __n, __global_offset, __acc...);
-#endif // __SPIRV__
+#endif // _ONEDPL_DETECT_SPIRV_COMPILATION
         return seq_impl(__item_id, __n, __global_offset, __acc...);
     }
 
@@ -276,7 +276,7 @@ struct transform_reduce
     _Size
     output_size(const _Size& __n, const ::std::uint16_t& __work_group_size) const
     {
-#ifndef __SPIRV__
+#ifndef _ONEDPL_DETECT_SPIRV_COMPILATION
         if constexpr (_Commutative::value)
         {
             _Size __items_per_work_group = __work_group_size * __iters_per_work_item;
@@ -286,7 +286,7 @@ struct transform_reduce
             _Size __last_wg_contrib = std::min(__last_wg_remainder, static_cast<_Size>(__work_group_size));
             return __full_group_contrib + __last_wg_contrib;
         }
-#endif // __SPIRV__
+#endif // _ONEDPL_DETECT_SPIRV_COMPILATION
 
         return oneapi::dpl::__internal::__dpl_ceiling_div(__n, __iters_per_work_item);
     }


### PR DESCRIPTION
## Rationale

Algorithms using `transform_reduce` (`std::reduce`, `std::max_element`, etc) return a single value result. They also, except for the smallest cases, require intermediate scratch memory on the device to hold partial results.

For L0 backend, it's faster to have a 1-element USM host allocation and to write the final reduction result directly to that.

For Nvidia, host USM is expensive, and it's faster instead to have a single USM device allocation for both the **result** and the **intermediate scratch**.

## Approach

This PR combines the two approaches into a struct `__usm_host_or_unified_storage`, based on the previous `__usm_host_or_buffer_storage`. When host USM is supported and the backend is L0, this struct holds two memory allocations (device USM for intermediate scratch, and host USM for final result). In all other cases, this struct holds a single device USM allocation, large enough for both intermediate scratch and final result. In this latter case, a `memcpy` from device to host is needed to return the final result.